### PR TITLE
switch to FFI::Platypus

### DIFF
--- a/Build.PL
+++ b/Build.PL
@@ -11,7 +11,7 @@ my $builder = Module::Build->new(
         'Test::More'  => 0,    # for testing
         'File::Temp'  => 0,    # for testing
         'File::Slurp' => 0,    # for testing
-        'FFI::Me'     => 0,
+        'FFI::Platypus' => 0.12,
     },
 
     # delete_share => '.', # NYI https://rt.cpan.org/Ticket/Display.html?id=92863

--- a/Makefile.PL
+++ b/Makefile.PL
@@ -20,7 +20,7 @@ WriteMakefile(
         'Test::More'  => 0,    # for testing
         'File::Temp'  => 0,    # for testing
         'File::Slurp' => 0,    # for testing
-        'FFI::Me'     => 0,
+        'FFI::Platypus' => 12,
     },
     dist  => { COMPRESS => 'gzip -9f', SUFFIX => 'gz', },
     clean => { FILES    => 'Lchmod-*' },

--- a/lib/Lchmod.pm
+++ b/lib/Lchmod.pm
@@ -2,7 +2,7 @@ package Lchmod;
 
 use strict;
 use warnings;
-use FFI::Me;
+use FFI::Platypus;
 
 $Lchmod::VERSION = '0.02';
 
@@ -30,11 +30,9 @@ sub import {
 {
     local $@;
     eval {                   # 1st: try current process
-        ffi _sys_lchmod => (
-            rv  => ffi::int,
-            arg => [ ffi::str, ffi::int ],
-            sym => 'lchmod',
-        );
+        my $ffi = FFI::Platypus->new;
+        $ffi->lib(undef); # search current process
+        $ffi->attach( [ lchmod => '_sys_lchmod' ] => [ 'string', 'mode_t' ] => 'int' );
     };
     $LCHMOD_AVAILABLE = 1 if !$@;
 }
@@ -157,7 +155,7 @@ Lchmod requires no configuration files or environment variables.
 
 =head1 DEPENDENCIES
 
-L<FFI::Me>
+L<FFI::Platypus>
 
 =head1 INCOMPATIBILITIES
 


### PR DESCRIPTION
I noticed that you are using `FFI::Raw` (indirectly) for `Lchmod` and thought that you might be interested in `FFI::Platypus`.  It will be faster for repeated calls to `_sys_lchmod`, mainly because there is no method dispatch on the `FFI::Raw` object (in the Platypus version _sys_lchmod is an xsub).  There are also other benefits as well for more complicated C APIs, but lchmod isn't that complicated :)
